### PR TITLE
Connector type id fix

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,7 +1,7 @@
 config-version: 2
 
 name: 'fivetran_log'
-version: '0.3.0'
+version: '0.3.1'
 
 require-dbt-version: [">=0.18.0", "<0.20.0"]
 

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -11,6 +11,8 @@ models:
         +schema: fivetran_log
         staging:
             +schema: stg_fivetran_log
+            tmp:
+                +materialized: view
 
 
 vars:

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'fivetran_log_integration_tests'
-version: '0.3.0'
+version: '0.3.1'
 config-version: 2
 profile: 'integration_tests'
 

--- a/macros/get_brand_columns.sql
+++ b/macros/get_brand_columns.sql
@@ -1,0 +1,19 @@
+{% macro get_connector_columns() %}
+
+{% set columns = [
+    {"name": "_fivetran_deleted", "datatype": "boolean"},
+    {"name": "_fivetran_synced", "datatype": dbt_utils.type_timestamp()},
+    {"name": "connecting_user_id", "datatype": dbt_utils.type_string()},
+    {"name": "connector_id", "datatype": dbt_utils.type_string()},
+    {"name": "connector_name", "datatype": dbt_utils.type_string()},
+    {"name": "connector_type", "datatype": dbt_utils.type_string()},
+    {"name": "connector_type_id", "datatype": dbt_utils.type_string()},
+    {"name": "destination_id", "datatype": dbt_utils.type_string()},
+    {"name": "paused", "datatype": "boolean"},
+    {"name": "service_version", "datatype": dbt_utils.type_int()},
+    {"name": "signed_up", "datatype": dbt_utils.type_timestamp()}
+] %}
+
+{{ return(columns) }}
+
+{% endmacro %}

--- a/models/staging/tmp/stg_fivetran_log__connector_tmp.sql
+++ b/models/staging/tmp/stg_fivetran_log__connector_tmp.sql
@@ -1,0 +1,2 @@
+select *
+from {{ var('connector') }}


### PR DESCRIPTION
This PR includes the following updates:

- Addresses Issue #14 by adding the `get_connector_columns` macro and `stg_fivetran_log__connector_tmp` model to the package in order to reflect the connector level change that resulted in removing the `connector_type` field and now only contains `connector_type_id`.
- Package version upgrade to v0.3.1

The addition of the macro allows for customers that are still using a previous version of the fivetran_log connector to use the package as well as allowing new fivetran_log connector users to successfully use the package without run failures due to the `connector_type` field not being included.