### PR TITLE
Fix spine start_date

### DIFF
--- a/models/fivetran_log__connector_daily_events.sql
+++ b/models/fivetran_log__connector_daily_events.sql
@@ -74,7 +74,7 @@ spine as (
 
     {{ dbt_utils.date_spine(
         datepart = "day", 
-        start_date =  "'" ~ first_date[0:10] ~ "'", 
+        start_date =  "cast('" ~ first_date[0:10] ~ "' as date)", 
         end_date = dbt_utils.dateadd("week", 1, dbt_utils.date_trunc('day', dbt_utils.current_timestamp())) 
         ) 
     }} 


### PR DESCRIPTION
On PostgreSQL, the start_date of the date_spine as string causes an error.



**Are you a current Fivetran customer?** 
Brice Luu, Freelance Data Engineer, currently implementing fivetran+dbt at Welcome to the Jungle.

**What change(s) does this PR introduce?** 
Explicitly casting as date the start_date of the date_spine dbt_utils function.

**Does this PR introduce a breaking change?**
- [ ] Yes (please provide breaking change details below.)
- [x] No  (please provide explanation how the change is non breaking below.)
It just fixes the `fivetran_log__connector_daily_events` model (doesn't work without this)

**Is this PR in response to a previously created Issue**
- [ ] Yes, Issue [link issue number here]
- [x] No 

**How did you test the PR changes?** 
- [ ] CircleCi <!--- CircleCi testing is only applicable to Fivetran employees. --> 
- [x] Other (please provide additional testing details below)
Manually ran `dbt run --select fivetran_log__connector_daily_events`
Output:
```
Running with dbt=0.21.0

Found 28 models, 48 tests, 1 snapshot, 1 analysis, 429 macros, 0 operations, 0 seed files, 36 sources, 0 exposures

10:21:34 | Concurrency: 2 threads (target='ods')
10:21:34 | 
10:21:34 | 1 of 1 START table model dbt_kian.fivetran_log__connector_daily_events [RUN]
10:21:41 | 1 of 1 OK created table model dbt_kian.fivetran_log__connector_daily_events [SELECT 399 in 7.39s]
10:21:41 | 
10:21:41 | Finished running 1 table model in 8.48s.

Completed successfully

Done. PASS=1 WARN=0 ERROR=0 SKIP=0 TOTAL=1
```

**Select which warehouse(s) were used to test the PR**
<!--- To check a warehouse remove the space and insert an x in the box (eg. [x] Bigquery). --> 
- [ ] BigQuery
- [ ] Redshift
- [ ] Snowflake
- [x] Postgres
- [ ] Databricks
- [ ] Other (provide details below)

**Provide an emoji that best describes your current mood**
<!--- For a complete list of markdown compatible emojis check our this git repo (https://gist.github.com/rxaviers/7360908)  --> 
:facepalm:

**Feedback**

Nil.