### PR TITLE
bugfix/timestamp casting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # dbt_fivetran_log v0.5.2
 ## Fixes
-- The `fivetran_log__connector_status` model uses a date function off of `created_at` from the `stg_fivetran_log__log` model. This fails on certain redshift destinations as the timestamp is synced as `timestamptz`. Therefore, the field within the staging model is cast using `dbt_utils.type_timestamp` to appropriately cast the field for downstream functions. Further, to future proof, timestamps were cast within the following staging models: `account`, `account_membership`, `active_volume`, `destination_membership`, `destination`, `log`, `transformation`, and `user`.
+- The `fivetran_log__connector_status` model uses a date function off of `created_at` from the `stg_fivetran_log__log` model. This fails on certain redshift destinations as the timestamp is synced as `timestamptz`. Therefore, the field within the staging model is cast using `dbt_utils.type_timestamp` to appropriately cast the field for downstream functions. Further, to future proof, timestamps were cast within the following staging models: `account`, `account_membership`, `active_volume`, `destination_membership`, `destination`, `log`, `transformation`, and `user`. ([#40](https://github.com/fivetran/dbt_fivetran_log/pull/40))
 # dbt_fivetran_log v0.5.1
 
 ## Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# dbt_fivetran_log v0.5.2
+## Fixes
+- The `fivetran_log__connector_status` model uses a date function off of `created_at` from the `stg_fivetran_log__log` model. This fails on certain redshift destinations as the timestamp is synced as `timestamptz`. Therefore, the field within the staging model is cast using `dbt_utils.type_timestamp` to appropriately cast the field for downstream functions. Further, to future proof, timestamps were cast within the following staging models: `account`, `account_membership`, `active_volume`, `destination_membership`, `destination`, `log`, `transformation`, and `user`.
 # dbt_fivetran_log v0.5.1
 
 ## Features

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,7 +1,7 @@
 config-version: 2
 
 name: 'fivetran_log'
-version: '0.5.1'
+version: '0.5.2'
 
 require-dbt-version: [">=1.0.0", "<2.0.0"]
 

--- a/integration_tests/ci/sample.profiles.yml
+++ b/integration_tests/ci/sample.profiles.yml
@@ -33,7 +33,7 @@ integration_tests:
       role: "{{ env_var('CI_SNOWFLAKE_DBT_ROLE') }}"
       database: "{{ env_var('CI_SNOWFLAKE_DBT_DATABASE') }}"
       warehouse: "{{ env_var('CI_SNOWFLAKE_DBT_WAREHOUSE') }}"
-      schema: fivetran_log_integration_tests
+      schema: fivetran_log_integration_test
       threads: 8
     postgres:
       type: postgres
@@ -42,12 +42,12 @@ integration_tests:
       pass: "{{ env_var('CI_POSTGRES_DBT_PASS') }}"
       dbname: "{{ env_var('CI_POSTGRES_DBT_DBNAME') }}"
       port: 5432
-      schema: fivetran_log_integration_tests
+      schema: fivetran_log_integration_test
       threads: 8
     spark:
       type: spark
       method: http
-      schema: fivetran_log_integration_tests
+      schema: fivetran_log_integration_test
       host: "{{ env_var('CI_SPARK_DBT_HOST') }}"
       organization: "{{ env_var('CI_SPARK_DBT_ORGANIZATION') }}"
       token: "{{ env_var('CI_SPARK_DBT_TOKEN') }}"

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'fivetran_log_integration_tests'
-version: '0.5.1'
+version: '0.5.2'
 config-version: 2
 profile: 'integration_tests'
 

--- a/models/staging/stg_fivetran_log__account.sql
+++ b/models/staging/stg_fivetran_log__account.sql
@@ -9,7 +9,7 @@ fields as (
     select
         id as account_id,
         country,
-        created_at,
+        cast(created_at as {{ dbt_utils.type_timestamp() }}) as created_at,
         name as account_name,
         status
         

--- a/models/staging/stg_fivetran_log__account_membership.sql
+++ b/models/staging/stg_fivetran_log__account_membership.sql
@@ -9,8 +9,8 @@ fields as (
     select
         account_id,
         user_id,
-        activated_at,
-        joined_at,
+        cast(activated_at as {{ dbt_utils.type_timestamp() }}) as activated_at,
+        cast(joined_at as {{ dbt_utils.type_timestamp() }}) as joined_at,
         role as account_role
         
     from account_membership

--- a/models/staging/stg_fivetran_log__active_volume.sql
+++ b/models/staging/stg_fivetran_log__active_volume.sql
@@ -10,7 +10,7 @@ fields as (
         id as active_volume_id,
         connector_id as connector_name, -- Note: this misnomer will be changed by Fivetran soon
         destination_id,
-        measured_at,
+        cast(measured_at as {{ dbt_utils.type_timestamp() }}) as measured_at,
         monthly_active_rows,
         schema_name,
         table_name

--- a/models/staging/stg_fivetran_log__destination.sql
+++ b/models/staging/stg_fivetran_log__destination.sql
@@ -9,7 +9,7 @@ fields as (
     select
         id as destination_id,
         account_id,
-        created_at,
+        cast(created_at as {{ dbt_utils.type_timestamp() }}) as created_at,
         name as destination_name,
         region
     

--- a/models/staging/stg_fivetran_log__destination_membership.sql
+++ b/models/staging/stg_fivetran_log__destination_membership.sql
@@ -9,8 +9,8 @@ fields as (
     select
         destination_id,
         user_id,
-        activated_at,
-        joined_at,
+        cast(activated_at as {{ dbt_utils.type_timestamp() }}) as activated_at,
+        cast(joined_at as {{ dbt_utils.type_timestamp() }}) as joined_at,
         role as destination_role
         
     from destination_membership

--- a/models/staging/stg_fivetran_log__log.sql
+++ b/models/staging/stg_fivetran_log__log.sql
@@ -8,7 +8,7 @@ fields as (
 
     select
         id as log_id, 
-        time_stamp as created_at,
+        cast(time_stamp as {{ dbt_utils.type_timestamp() }}) as created_at,
         connector_id, -- Note: the connector_id column used to erroneously equal the connector_name, NOT its id.
         case when transformation_id is not null and event is null then 'TRANSFORMATION'
         else event end as event_type, 

--- a/models/staging/stg_fivetran_log__transformation.sql
+++ b/models/staging/stg_fivetran_log__transformation.sql
@@ -10,7 +10,7 @@ fields as (
 
     select
         id as transformation_id,
-        created_at,
+        cast(created_at as {{ dbt_utils.type_timestamp() }}) as created_at,
         created_by_id as created_by_user_id,
         destination_id,
         name as transformation_name,

--- a/models/staging/stg_fivetran_log__user.sql
+++ b/models/staging/stg_fivetran_log__user.sql
@@ -8,7 +8,7 @@ fields as (
 
     select
         id as user_id,
-        created_at,
+        cast(created_at as {{ dbt_utils.type_timestamp() }}) as created_at,
         email,
         email_disabled as has_disabled_email_notifications,
         family_name as last_name,


### PR DESCRIPTION
**Are you a current Fivetran customer?** 
<!--- Please tell us your name, title and company -->
Fivetran created PR

**What change(s) does this PR introduce?** 
<!--- Describe what changes your PR introduces to the package and how to leverage this new feature. -->
The `fivetran_log__connector_status` model uses a date function off of `created_at` from the `stg_fivetran_log__log` model. This fails on certain redshift destinations as the timestamp is synced as `timestamptz`. Therefore, the field within the staging model is cast using `dbt_utils.type_timestamp` to appropriately cast the field for downstream functions. Further, to future proof, timestamps were cast within the following staging models: `account`, `account_membership`, `active_volume`, `destination_membership`, `destination`, `log`, `transformation`, and `user`.

**Did you update the CHANGELOG?** 
<!--- Please update the new package version’s CHANGELOG entry detailing the changes included in this PR. -->
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [X] Yes

**Does this PR introduce a breaking change?**
<!--- Does this PR introduce changes that will cause current package users' jobs to fail or require a `--full-refresh`? -->
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [ ] Yes (please provide breaking change details below.)
- [X] No  (please provide an explanation as to how the change is non-breaking below.)

This change is simply casting fields in the staging models as timestamps using dbt_utils. This will not be breaking for existing users.

**Did you update the dbt_project.yml files with the version upgrade (please leverage standard semantic versioning)? (In both your main project and integration_tests)** 
<!--- The dbt_project.yml and the integration_tests/dbt_project.yml files contain the version number. Be sure to upgrade it accordingly -->
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [X] Yes

**Is this PR in response to a previously created Bug or Feature Request**
<!--- If an Issue was created it is helpful to track the progress by linking it in the PR. -->
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [Z] Yes, [dbt Slack issue identified](https://getdbt.slack.com/archives/C01D1R2JLLA/p1646076699137299)
- [ ] No 

**How did you test the PR changes?** 
<!--- Proof of testing is required in order for the PR to be approved. -->
<!--- To check a box, remove the space and insert an x in the box (eg. [x] CircleCi). --> 
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [X] CircleCi <!--- CircleCi testing is only applicable to Fivetran employees. --> 
- [X] Local (please provide additional testing details below)

Tested this against our local dataset. Further, asked the customer to test on their Redshift instance.

**Select which warehouse(s) were used to test the PR**
<!--- To check a warehouse remove the space and insert an x in the box (eg. [x] Bigquery). --> 
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [X] BigQuery
- [X] Redshift
- [X] Snowflake
- [X] Postgres
- [X] Databricks
- [ ] Other (provide details below)

**Provide an emoji that best describes your current mood**
<!--- For a complete list of markdown compatible emojis check our this git repo (https://gist.github.com/rxaviers/7360908)  --> 
🌲 

**Feedback**

We are so excited you decided to contribute to the Fivetran community dbt package! We continue to work to improve the packages and would greatly appreciate your [feedback](https://www.surveymonkey.com/r/DQ7K7WW) on our existing dbt packages or what you'd like to see next.
