### PR TITLE
addition of the usage cost source and logic to use the proper table

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -28,3 +28,4 @@ vars:
     transformation: "{{ source('fivetran_log', 'transformation') }}"
     trigger_table: "{{ source('fivetran_log', 'trigger_table') }}"
     user: "{{ source('fivetran_log', 'user') }}"
+    usage_cost: "{{ source('fivetran_log', 'usage_cost') }}"

--- a/macros/does_table_exist.sql
+++ b/macros/does_table_exist.sql
@@ -1,0 +1,17 @@
+{%- macro does_table_exist(table_name) -%}
+    {%- if execute -%}
+    {%- set ns = namespace(has_table=false) -%}
+        {%- for node in graph.sources.values() -%}
+        -- call the database for the matching table
+            {%- set source_relation = adapter.get_relation(
+                    database=node.database,
+                    schema=node.schema,
+                    identifier=node.name ) -%} 
+            {%- if source_relation == None and node.name == table_name -%} 
+                {{ return(False) }}
+            {%- elif source_relation != None and node.name == table_name -%} 
+                {{ return(True) }}
+            {% endif %}
+        {%- endfor -%}
+    {%- endif -%} 
+{%- endmacro -%}

--- a/models/fivetran_log.yml
+++ b/models/fivetran_log.yml
@@ -133,8 +133,8 @@ models:
       - name: destination_name
         description: Name of the destination as it appears in the UI.
 
-      - name: credits_consumed
-        description: The number of credits used by the destination for the given month.
+      - name: consumption
+        description: The number of credits or dollar amount used by the destination for the given month.
 
       - name: monthly_active_rows
         description: The number of total active rows measured in the destination for the month.

--- a/models/fivetran_log__credit_mar_destination_history.sql
+++ b/models/fivetran_log__credit_mar_destination_history.sql
@@ -4,6 +4,12 @@ with table_mar as (
     from {{ ref('fivetran_log__mar_table_history') }}
 ),
 
+consumption_cost as (
+    select *
+    from {{ ref('stg_fivetran_log__credits_used') }}
+
+),
+
 destination_mar as (
 
     select 
@@ -16,14 +22,14 @@ destination_mar as (
     group by 1,2,3
 ),
 
-credits_used as (
+usage as (
 
     select 
         destination_id,
-        credits_consumed,
+        consumption_amount as consumption,
         cast(concat(measured_month, '-01') as date) as measured_month -- match date format to join with MAR table
 
-    from {{ ref('stg_fivetran_log__credits_used') }}
+    from consumption_cost
 ),
 
 join_credits_mar as (
@@ -32,15 +38,15 @@ join_credits_mar as (
         destination_mar.measured_month,
         destination_mar.destination_id,
         destination_mar.destination_name,
-        credits_used.credits_consumed,
+        usage.consumption,
         destination_mar.monthly_active_rows,
-        round( nullif(credits_used.credits_consumed,0) * 1000000.0 / nullif(destination_mar.monthly_active_rows,0), 2) as credits_per_million_mar,
-        round( nullif(destination_mar.monthly_active_rows,0) * 1.0 / nullif(credits_used.credits_consumed,0), 0) as mar_per_credit
+        round( nullif(usage.consumption,0) * 1000000.0 / nullif(destination_mar.monthly_active_rows,0), 2) as credits_per_million_mar,
+        round( nullif(destination_mar.monthly_active_rows,0) * 1.0 / nullif(usage.consumption,0), 0) as mar_per_credit
 
     from 
-    destination_mar left join credits_used 
-        on destination_mar.measured_month = cast(credits_used.measured_month as timestamp)
-        and destination_mar.destination_id = credits_used.destination_id
+    destination_mar left join usage 
+        on destination_mar.measured_month = cast(usage.measured_month as timestamp)
+        and destination_mar.destination_id = usage.destination_id
 
 )
 

--- a/models/staging/src_fivetran_log.yml
+++ b/models/staging/src_fivetran_log.yml
@@ -12,7 +12,7 @@ sources:
       warn_after: {count: 72, period: hour}
       error_after: {count: 96, period: hour}
 
-    tables: 
+    tables:        
       - name: active_volume
         description: >
           Table of **monthly active row (MAR)** measurements made by table per date. 
@@ -64,6 +64,16 @@ sources:
             description: The month (yyyy-mm) in which the credits were consumed.
           - name: credits_consumed
             description: The number of credits used by the destination for the given month.
+
+      - name: usage_cost
+        description: Table of the credits used by the customer per month within each destination.
+        columns:
+          - name: destination_id
+            description: Foreign key referencing the `destination` warehouse that the credits were used on
+          - name: measured_month
+            description: The month (yyyy-mm) in which the credits were consumed.
+          - name: amount
+            description: The dollar amount associated with the cost of your connector.
 
       - name: destination
         description: Table of the destinations that have data loaded into them. For each declared source, there will be just one record.

--- a/models/staging/stg_fivetran_log.yml
+++ b/models/staging/stg_fivetran_log.yml
@@ -65,8 +65,8 @@ models:
         description: Foreign key referencing the `destination` warehouse that the credits were used on.
       - name: measured_month
         description: The month (yyyy-mm) in which the credits were consumed.
-      - name: credits_consumed
-        description: The number of credits used by the destination for the given month.
+      - name: consumption_amount
+        description: The number of credits or dollar amount used by the destination for the given month.
 
   - name: stg_fivetran_log__destination
     description: Table of the destinations that have data loaded into them. For each declared source, there will be just one record.

--- a/models/staging/stg_fivetran_log__credits_used.sql
+++ b/models/staging/stg_fivetran_log__credits_used.sql
@@ -1,6 +1,8 @@
-with  credits_used as (
+{% if var('fivetran_log__usage_pricing', does_table_exist('usage_cost')) %}
+with usage as (
 
-    select * from {{ var('credits_used') }}
+    select * 
+    from {{ var('usage_cost') }}
 
 ),
 
@@ -9,9 +11,34 @@ fields as (
     select 
         destination_id,
         measured_month,
-        credits_consumed
+        amount as consumption_amount
+    
+    from usage
+)
+
+select * 
+from fields
+
+{% else %}
+
+with credits_used as (
+
+    select * 
+    from {{ var('credits_used') }}
+
+),
+
+fields as (
+    
+    select 
+        destination_id,
+        measured_month,
+        credits_consumed as consumption_amount
     
     from credits_used
 )
 
-select * from fields
+select * 
+from fields
+
+{% endif %}


### PR DESCRIPTION
**Are you a current Fivetran customer?** 
<!--- Please tell us your name, title and company -->
Fivetran created PR

**What change(s) does this PR introduce?** 
<!--- Describe what changes your PR introduces to the package and how to leverage this new feature. -->
This PR does a couple things that important to call out:
- This package adds the new `usage_cost` source to the package. This source table will take the place of the `credits_used` model.
- However, the `usage_cost` model is not yet rolled out to all Fivetran Log users as this only is relevant for individuals on the new pricing model.
- Therefore, this PR incorporates some pretty unique logic to check and see if the user has the `usage_cost` source table within their schema using the `does_table_exist()` macro.
  - I am not sold on the name of the macro at the moment and will plan to move this to `fivetran_utils`.
- When running the `stg_fivetran_log__credits_used` (name will most likely change) model, the macro is called and used to update the `fivetran_log__usage_pricing` variable. The variable will be `true` if the `usage_cost` source is identified. If not, the variable will be `false`.
- If the variable is true then the model will run leveraging the `usage_cost` source. Otherwise, the `credits_used` source will be used.
- Downstream models and yml docs were updated to account for these changes. 

**Did you update the CHANGELOG?** 
<!--- Please update the new package version’s CHANGELOG entry detailing the changes included in this PR. -->
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [ ] Yes

**Does this PR introduce a breaking change?**
<!--- Does this PR introduce changes that will cause current package users' jobs to fail or require a `--full-refresh`? -->
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [ ] Yes (please provide breaking change details below.)
- [x] No  (please provide an explanation as to how the change is non-breaking below.)

Weirdly enough I do not believe this will be a breaking change... but maybe we should make it breaking as it will be a big update?

**Did you update the dbt_project.yml files with the version upgrade (please leverage standard semantic versioning)? (In both your main project and integration_tests)** 
<!--- The dbt_project.yml and the integration_tests/dbt_project.yml files contain the version number. Be sure to upgrade it accordingly -->
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [ ] Yes

**Is this PR in response to a previously created Bug or Feature Request**
<!--- If an Issue was created it is helpful to track the progress by linking it in the PR. -->
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [ ] Yes, Issue/Feature [link bug/feature number here]
- [X] No 

**How did you test the PR changes?** 
<!--- Proof of testing is required in order for the PR to be approved. -->
<!--- To check a box, remove the space and insert an x in the box (eg. [x] CircleCi). --> 
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [ ] CircleCi <!--- CircleCi testing is only applicable to Fivetran employees. --> 
- [X] Local (please provide additional testing details below)

**Select which warehouse(s) were used to test the PR**
<!--- To check a warehouse remove the space and insert an x in the box (eg. [x] Bigquery). --> 
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->

** FYI Seed data and integration tests have not been added yet. They need to be added before moving out of draft **
- [ ] BigQuery
- [ ] Redshift
- [ ] Snowflake
- [ ] Postgres
- [ ] Databricks
- [ ] Other (provide details below)

**Provide an emoji that best describes your current mood**
<!--- For a complete list of markdown compatible emojis check our this git repo (https://gist.github.com/rxaviers/7360908)  --> 
🤯 

**Feedback**

We are so excited you decided to contribute to the Fivetran community dbt package! We continue to work to improve the packages and would greatly appreciate your [feedback](https://www.surveymonkey.com/r/DQ7K7WW) on our existing dbt packages or what you'd like to see next.
