### PR TITLE
Bugfix/transformation log and changelog test

### DIFF
--- a/integration_tests/ci/sample.profiles.yml
+++ b/integration_tests/ci/sample.profiles.yml
@@ -47,7 +47,7 @@ integration_tests:
     spark:
       type: spark
       method: http
-      schema: fivetran_log_integration__test
+      schema: fivetranlog_integration__test
       host: "{{ env_var('CI_SPARK_DBT_HOST') }}"
       organization: "{{ env_var('CI_SPARK_DBT_ORGANIZATION') }}"
       token: "{{ env_var('CI_SPARK_DBT_TOKEN') }}"

--- a/models/fivetran_log.yml
+++ b/models/fivetran_log.yml
@@ -290,6 +290,7 @@ models:
           combination_of_columns: 
             - connector_id
             - destination_id
+            - message_data
             - created_at
     columns:
       - name: connector_id

--- a/models/fivetran_log__connector_status.sql
+++ b/models/fivetran_log__connector_status.sql
@@ -1,10 +1,15 @@
-with connector_log as (
+with transformation_removal as (
 
     select *,
         sum( case when event_subtype in ('sync_start') then 1 else 0 end) over ( partition by connector_id 
             order by created_at rows unbounded preceding) as sync_batch_id
     from {{ ref('stg_fivetran_log__log') }}
+    where event_subtype != 'TRANSFORMATION'
+),
 
+connector_log as (
+    select *
+    from transformation_removal
     -- only looking at errors, warnings, and syncs here
     where event_type = 'SEVERE'
         or event_type = 'WARNING'

--- a/models/staging/stg_fivetran_log__log.sql
+++ b/models/staging/stg_fivetran_log__log.sql
@@ -22,4 +22,6 @@ fields as (
     from log
 )
 
-select * from fields 
+select * 
+from fields 
+where transformation_id is null

--- a/models/staging/stg_fivetran_log__log.sql
+++ b/models/staging/stg_fivetran_log__log.sql
@@ -24,4 +24,3 @@ fields as (
 
 select * 
 from fields 
-where transformation_id is null

--- a/models/staging/stg_fivetran_log__transformation.sql
+++ b/models/staging/stg_fivetran_log__transformation.sql
@@ -25,4 +25,3 @@ fields as (
 )
 
 select * from fields
-where transformation_id is not null


### PR DESCRIPTION
**Are you a current Fivetran customer?** 
<!--- Please tell us your name, title and company -->
Fivetran created PR

**What change(s) does this PR introduce?** 
<!--- Describe what changes your PR introduces to the package and how to leverage this new feature. -->
This PR makes two notable changes:
1. The `unique_combination_of_columns` schema test for the `fivetran_log__schema_changelog` model has been adjusted to also account for the `message_data` field. This adjustment is necessary as the Fivetran Log connector has been modified to sync multiple records at the same time. Therefore, multiple schema changes may come in at the same time. Therefore, we now want to look at the actual change for uniqueness as well.
2. A number of customers have noted that their `fivetran_log__connector_status` model fails due to JSON parsing not being able to be performed on non-JSON fields (this is only occurring in Snowflake instances). It was found that these non-JSON fields are limited **only** to `TRANSFORMATIONS` event_subtypes. Since transformation logs are not needed in this model in the first place, an adjustment has been made to filter the records out before further modeling takes place. 
   - Please note I broke this out into separate CTEs since we needed to first filter out all transformations and then do our normal filtering.

**Did you update the CHANGELOG?** 
<!--- Please update the new package version’s CHANGELOG entry detailing the changes included in this PR. -->
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [X] Yes

**Does this PR introduce a breaking change?**
<!--- Does this PR introduce changes that will cause current package users' jobs to fail or require a `--full-refresh`? -->
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [ ] Yes (please provide breaking change details below.)
- [X] No  (please provide an explanation as to how the change is non-breaking below.)

This is a bug fix that will not impact existing customers package runs.

**Did you update the dbt_project.yml files with the version upgrade (please leverage standard semantic versioning)? (In both your main project and integration_tests)** 
<!--- The dbt_project.yml and the integration_tests/dbt_project.yml files contain the version number. Be sure to upgrade it accordingly -->
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [X] Yes

**Is this PR in response to a previously created Bug or Feature Request**
<!--- If an Issue was created it is helpful to track the progress by linking it in the PR. -->
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [X] Yes, Issue #49 and #45 and #46 
- [ ] No 

**How did you test the PR changes?** 
<!--- Proof of testing is required in order for the PR to be approved. -->
<!--- To check a box, remove the space and insert an x in the box (eg. [x] CircleCi). --> 
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [X] CircleCi <!--- CircleCi testing is only applicable to Fivetran employees. --> 
- [X] Local (please provide additional testing details below)

This succeeded on my local branch as well as customers in addition to CircleCi.

**Select which warehouse(s) were used to test the PR**
<!--- To check a warehouse remove the space and insert an x in the box (eg. [x] Bigquery). --> 
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [X] BigQuery
- [X] Redshift
- [X] Snowflake
- [X] Postgres
- [ ] Databricks
- [ ] Other (provide details below)

**Provide an emoji that best describes your current mood**
<!--- For a complete list of markdown compatible emojis check our this git repo (https://gist.github.com/rxaviers/7360908)  --> 
🧪 

**Feedback**

We are so excited you decided to contribute to the Fivetran community dbt package! We continue to work to improve the packages and would greatly appreciate your [feedback](https://www.surveymonkey.com/r/DQ7K7WW) on our existing dbt packages or what you'd like to see next.
