### PR TITLE
Changed the identifier argument from name to identifier 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# dbt_fivetran_log v0.6.3
+## Fixes
+- Modified the argument used for the identifier in the get_relation macro used in the does_table_exist macro from name to identifier. This avoids issues on snowflake where the name of a table defined in a source yaml may be in lowercase while in snowflake it is uppercased.
+## Contributors
+- [@ggmblr](https://github.com/ggmblr) ([#60](https://github.com/fivetran/dbt_fivetran_log/pull/60))
+
 # dbt_fivetran_log v0.6.2
 ## Fixes
 - Extend model disablement with `config: is_enabled` setting in sources to avoid running source freshness when a model is disabled. ([#58](https://github.com/fivetran/dbt_fivetran_log/pull/58))

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,7 +1,7 @@
 config-version: 2
 
 name: 'fivetran_log'
-version: '0.6.2'
+version: '0.6.3'
 
 require-dbt-version: [">=1.0.0", "<2.0.0"]
 

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'fivetran_log_integration_tests'
-version: '0.6.2'
+version: '0.6.3'
 config-version: 2
 profile: 'integration_tests'
 

--- a/macros/does_table_exist.sql
+++ b/macros/does_table_exist.sql
@@ -6,7 +6,7 @@
             {%- set source_relation = adapter.get_relation(
                     database=node.database,
                     schema=node.schema,
-                    identifier=node.name ) -%} 
+                    identifier=node.identifier ) -%} 
             {%- if source_relation == None and node.name | lower == table_name | lower -%} 
                 {{ return(False) }} -- return false if relation identified by the database.schema.identifier does not exist for the given table name
             {%- elif source_relation != None and node.name | lower == table_name | lower -%} 


### PR DESCRIPTION
Changed the identifier argument from name to identifier to avoid issues on snowflake with ambiguous naming of the relations.

Pull Request
**Are you a current Fivetran customer?** 
<!--- Please tell us your name, title and company -->
Simon Herzog, Analytics Engineer, Wallbox

**What change(s) does this PR introduce?** 
<!--- Describe what changes your PR introduces to the package and how to leverage this new feature. -->
This PR changes the identifier argument of the `does_table_exist` macro as described in this [issue](https://github.com/fivetran/dbt_fivetran_log/issues/60).
**Did you update the CHANGELOG?** 
<!--- Please update the new package version’s CHANGELOG entry detailing the changes included in this PR. -->
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [x] Yes

**Does this PR introduce a breaking change?**
<!--- Does this PR introduce changes that will cause current package users' jobs to fail or require a `--full-refresh`? -->
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [ ] Yes (please provide breaking change details below.)
- [x] No  (please provide an explanation as to how the change is non-breaking below.)

This change only affects the way how the macro searches for the `usage_cost` table in the DWH, from using the defined name in a source yml to using the identifier.

**Did you update the dbt_project.yml files with the version upgrade (please leverage standard semantic versioning)? (In both your main project and integration_tests)** 
<!--- The dbt_project.yml and the integration_tests/dbt_project.yml files contain the version number. Be sure to upgrade it accordingly -->
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [x] Yes

**Is this PR in response to a previously created Bug or Feature Request**
<!--- If an Issue was created it is helpful to track the progress by linking it in the PR. -->
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [x] Yes, Issue/Feature [#60](https://github.com/fivetran/dbt_fivetran_log/issues/60)
- [ ] No 

**How did you test the PR changes?** 
<!--- Proof of testing is required in order for the PR to be approved. -->
<!--- To check a box, remove the space and insert an x in the box (eg. [x] CircleCi). --> 
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [ ] CircleCi <!--- CircleCi testing is only applicable to Fivetran employees. --> 
- [x] Local (please provide additional testing details below)
As described in the issue i opened this was tested by modifying the package locally inside our dbt project.

**Select which warehouse(s) were used to test the PR**
<!--- To check a warehouse remove the space and insert an x in the box (eg. [x] Bigquery). --> 
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [ ] BigQuery
- [ ] Redshift
- [x] Snowflake
- [ ] Postgres
- [ ] Databricks
- [ ] Other (provide details below)

**Provide an emoji that best describes your current mood**
<!--- For a complete list of markdown compatible emojis check our this git repo (https://gist.github.com/rxaviers/7360908)  --> 
:japanese_goblin:

**Feedback**

We are so excited you decided to contribute to the Fivetran community dbt package! We continue to work to improve the packages and would greatly appreciate your [feedback](https://www.surveymonkey.com/r/DQ7K7WW) on our existing dbt packages or what you'd like to see next.
