### PR TITLE
Refactor return logic in is_databricks_all_purpose_cluster

### DIFF
--- a/macros/is_databricks_all_purpose_cluster.sql
+++ b/macros/is_databricks_all_purpose_cluster.sql
@@ -9,7 +9,11 @@
         {% set path_match = target.http_path %}
         {% set regex_pattern = "sql/protocol" %}
         {% set match_result = re.search(regex_pattern, path_match) %}
-        {{ return(True) if match_result else return(False) }}
+        {% if match_result %}
+            {{ return(True) }}
+        {% else %}
+            {{ return(False) }}
+        {% endif %}
     {% else %}
         {{ return(False) }}
     {% endif %}


### PR DESCRIPTION
Fix for dbt Fusion. The new logic works across Fusion and dbt-core

We had a chat a few weeks ago about the syntax
```
{{ return(True) if match_result else return(False) }}
```

which looked like it was working in Fusion but the team mentioned that this is actually not supported, so this PR is moving to the supported
```
        {% if match_result %}
            {{ return(True) }}
        {% else %}
            {{ return(False) }}
        {% endif %}
```